### PR TITLE
fix: JSON errors in 4 hardpointdatadef files (trailing commas, duplicate entries)

### DIFF
--- a/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_bowman.json
+++ b/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_bowman.json
@@ -5,13 +5,13 @@
             "location" : "leftarm",
             "weapons" : [
 			[
-			"chrprfweap_bowman_leftarm_laser_eh1",
+			"chrprfweap_bowman_leftarm_laser_eh1"
 			],
 			[
-			"chrprfweap_bowman_leftarm_laser_eh2",
+			"chrprfweap_bowman_leftarm_laser_eh2"
 			],
 			[
-			"chrprfweap_bowman_leftarm_laser_eh3",
+			"chrprfweap_bowman_leftarm_laser_eh3"
 			]
 			],
             "blanks" : [],

--- a/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_ionvulture.json
+++ b/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_ionvulture.json
@@ -1,12 +1,6 @@
 {
 	"ID": "hardpointdatadef_ionvulture",
 	"HardpointData": [{
-			"location": "leftarm",
-			"weapons": [],
-			"blanks": [],
-			"mountingPoints": []
-		},
-		{
 			"location": "lefttorso",
 			"weapons": [
 				[

--- a/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_madcat.json
+++ b/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_madcat.json
@@ -36,7 +36,7 @@
 			"chrPrfWeap_madcat_lefttorso_flamer_eh1",
 			"chrPrfWeap_madcat_lefttorso_ac20_bh1",
 			"chrPrfWeap_madcat_lefttorso_gauss_bh1",
-			"chrPrfWeap_madcat_lefttorso_mg_bh1",			
+			"chrPrfWeap_madcat_lefttorso_mg_bh1"			
 			],
 			[
 			"chrPrfWeap_madcat_lefttorso_srm20_mh1",
@@ -94,7 +94,7 @@
 			"chrPrfWeap_madcat_righttorso_flamer_eh1",
 			"chrPrfWeap_madcat_righttorso_ac20_bh1",
 			"chrPrfWeap_madcat_righttorso_gauss_bh1",
-			"chrPrfWeap_madcat_righttorso_mg_bh1",			
+			"chrPrfWeap_madcat_righttorso_mg_bh1"			
 			],
 			[
 			"chrPrfWeap_madcat_righttorso_srm20_mh1",

--- a/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_mwostonerhino.json
+++ b/CAB-Clan-GoldenCentury/hardpoints/hardpointdatadef_mwostonerhino.json
@@ -47,7 +47,6 @@
 			]
 			],
             "blanks" : [],
-            "blanks" : [],
             "mountingPoints" : []
         },
         {


### PR DESCRIPTION
## Summary

- `hardpointdatadef_bowman.json`: trailing commas inside weapon slot arrays — invalid JSON.
- `hardpointdatadef_madcat.json`: trailing commas inside weapon slot arrays — invalid JSON.
- `hardpointdatadef_mwostonerhino.json`: duplicate `"blanks"` key in the `righttorso` entry (copy-paste artifact; both values were empty `[]` — second removed).
- `hardpointdatadef_ionvulture.json`: duplicate `leftarm` entry in `HardpointData`. The first entry had empty `weapons: []` (a leftover placeholder); the second had all the real weapon prefabs. Removed the empty placeholder.

Found by the JSON validator in `.github/workflows/validate.yml`.